### PR TITLE
feat: allow ordering by related objects sub fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,14 +163,21 @@ class BookViewSet(GenericViewSet, AggregationMixin):
 ```
 You can use 'lt', 'lte', 'gt', 'gte', 'exact' and  &#95;&#95;all&#95;&#95; as values for the **aggregated_filtering_fields** class variable.
 
-To order the queryset, you can use the standard Django ordering filter.
-
+Fields available for ordering the result are taken from the `aggregated_ordering_fields` attribute.
 ```python
 class BookViewSet(GenericViewSet, AggregationMixin):
     queryset = Book.objects.all()
     serializer_class = BookSerializer
-    ordering_fields = ['value', 'grouped_by_field']
+    aggregated_ordering_fields = ['value', 'grouped_by_field']
 ```
-
+if this is not set available fields are taken from the usual `ordering_fields` attribute.
+The reason for this behaviour is to accommodate interplay with the often used `OrderingFilter` 
+```python
+class BookViewSet(GenericViewSet, AggregationMixin):
+    queryset = Book.objects.all()
+    serializer_class = BookSerializer
+    ordering_fields = ['page_count', 'author']
+```
+If no ordering fields of any kind are specified or the list contains `"__all__"` any passed ordering will be tried to be applied.
 ``ordering_fields = __all__`` is also possible.
 

--- a/src/django_rest_aggregation/mixins.py
+++ b/src/django_rest_aggregation/mixins.py
@@ -60,13 +60,15 @@ class AggregationMixin:
         return queryset
 
     def remove_invalid_ordering_fields(self, queryset, fields):
-        valid_fields = getattr(self, "aggregated_ordering_fields", None) or (
-            queryset[0].keys() if queryset.exists() else [])
+        ordering_fields = getattr(self, "aggregated_ordering_fields", None) or getattr(self, "ordering_fields", None)
+
+        if not ordering_fields or ("__all__" in ordering_fields) or (ordering_fields == "__all__"):
+            return fields
 
         def term_valid(term):
             if term.startswith("-"):
                 term = term[1:]
-            return term in valid_fields
+            return term in ordering_fields
 
         return [term for term in fields if term_valid(term)]
 

--- a/src/django_rest_aggregation/mixins.py
+++ b/src/django_rest_aggregation/mixins.py
@@ -10,23 +10,22 @@ from .serializers import AggregationSerializer
 class AggregationMixin:
     @action(methods=["get"], detail=False, url_path="aggregation", url_name="aggregation")
     def aggregation(self, request):
-        queryset = self.get_queryset().order_by()
-
-        if DjangoFilterBackend in self.filter_backends:
-            queryset = DjangoFilterBackend().filter_queryset(request, queryset, self)
+        queryset = self.filter_queryset(self.get_queryset())
 
         aggregator = Aggregator(request, queryset, self.get_aggregation_name())
-        filtered_queryset = self.filter_aggregated_queryset(aggregator.get_aggregated_queryset())
+        queryset = aggregator.get_aggregated_queryset()
+        queryset = self.filter_aggregated_queryset(queryset)
+        queryset = self.order_aggregated_queryset(queryset)
 
         context = {
             "request": request,
             "name": self.get_aggregation_name()
         }
-        page = self.paginate_queryset(filtered_queryset)
+        page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_aggregation_serializer_class(page, many=True, context=context)
             return self.get_paginated_response(serializer.data)
-        serializer = self.get_aggregation_serializer_class(filtered_queryset, many=True, context=context)
+        serializer = self.get_aggregation_serializer_class(queryset, many=True, context=context)
         return Response(serializer.data)
 
     def get_aggregation_serializer_class(self, *args, **kwargs):
@@ -42,30 +41,36 @@ class AggregationMixin:
         return "value"
 
     def filter_aggregated_queryset(self, queryset):
-        ordering_fields = getattr(self, "ordering_fields", [])
-        valid_fields = queryset[0].keys() if queryset.exists() else []
-
-        if ordering_fields == "__all__":
-            ordering_fields = valid_fields
-        else:
-            ordering_fields = list(set(ordering_fields).intersection(set(valid_fields)))
-
         if (fields := getattr(self, "aggregated_filterset_fields", None)) is not None:
             ValueFilter.set_filter_fields(fields, self.get_aggregation_name())
         filterset_class = getattr(self, "aggregated_filterset_class", ValueFilter)
-
-        helper_view = HelperView(ordering_fields, filterset_class)
-
-        for backend in list(self.filter_backends):
-            queryset = backend().filter_queryset(self.request, queryset, helper_view)
-
-        if not queryset.ordered:
-            queryset = queryset.order_by(*valid_fields)
+        helper_view = HelperView(filterset_class)
+        queryset = DjangoFilterBackend().filter_queryset(self.request, queryset, helper_view)
 
         return queryset
 
+    def order_aggregated_queryset(self, queryset):
+        params = self.request.query_params.get("order_by")
+        if params:
+            fields = [param.strip() for param in params.split(',')]
+            ordering = self.remove_invalid_ordering_fields(queryset, fields)
+            if ordering:
+                return queryset.order_by(*ordering)
+
+        return queryset
+
+    def remove_invalid_ordering_fields(self, queryset, fields):
+        valid_fields = getattr(self, "aggregated_ordering_fields", None) or (
+            queryset[0].keys() if queryset.exists() else [])
+
+        def term_valid(term):
+            if term.startswith("-"):
+                term = term[1:]
+            return term in valid_fields
+
+        return [term for term in fields if term_valid(term)]
+
 
 class HelperView:
-    def __init__(self, ordering_fields, filterset_class):
-        setattr(self, "ordering_fields", ordering_fields)
+    def __init__(self, filterset_class):
         setattr(self, "filterset_class", filterset_class)


### PR DESCRIPTION
Allows for arbitrary ordering fields to be added via the `aggregated_ordering_fields` attribute of the viewset